### PR TITLE
Fix small bug on WP 4.4

### DIFF
--- a/functions/editor.php
+++ b/functions/editor.php
@@ -301,7 +301,7 @@ jQuery(document).ready(function($) {
 									<strong title="<?php esc_attr_e($img_size_name) ?>"><?php echo $value['name'] ?><?php echo $_lowResWarning; ?></strong><?php echo $special_warning; ?>
 									<span class="dimensions"><?php _e('Dimensions:',CROP_THUMBS_LANG) ?> <?php echo $print_dimensions; ?></span>
 									<span class="ratio"><?php _e('Ratio:',CROP_THUMBS_LANG) ?> <?php echo $print_ratio; ?></span>
-									<img src="<?php echo $img_data[0]?>?<?php echo $cache_breaker ?>" data-values="<?php esc_attr_e(json_encode($jsonDataValues)); ?>" />
+									<img src="<?php echo $img_data[0]?>?<?php echo $cache_breaker ?>" data-values='<?php esc_attr_e(json_encode($jsonDataValues)); ?>' />
 								</li>
 							<?php endif; ?>
 						<?php endforeach; ?>


### PR DESCRIPTION
On Wordpress 4.4.x, `esc_attr_e(json_encode($jsonDataValues))` breaks thumbnail's data-value attribute, so I've changed the double quotes to single ones.

![screen shot 2015-12-29 at 13 31 17](https://cloud.githubusercontent.com/assets/527879/12034382/7677e304-ae30-11e5-87be-c3854de27804.png)
