### PR TITLE
Ignores when there is no featured image box.

### DIFF
--- a/functions/backendpreparer.php
+++ b/functions/backendpreparer.php
@@ -78,6 +78,11 @@ jQuery(document).ready(function($) {
 		 */
 		var baseElem = $('#postimagediv');
 		var featuredImageLinkButton = '';
+		
+		if(!baseElem.length) {
+			return;
+		}
+		
 		featuredImageLinkButton+= '<p class="cropFeaturedImageWrap hidden">';
 		featuredImageLinkButton+= '<a class="button cropThumbnailsLink" href="#" data-cropthumbnail=\'{"image_id":'+ parseInt(wp.media.featuredImage.get()) +',"viewmode":"single"}\' title="<?php esc_attr_e('Crop Featured Image',CROP_THUMBS_LANG) ?>">';
 		featuredImageLinkButton+= '<span class="wp-media-buttons-icon"></span> <?php esc_html_e('Crop Featured Image',CROP_THUMBS_LANG); ?>';


### PR DESCRIPTION
Checks if the current page have a featured image box in the first place.  It will throw an error: "Uncaught TypeError: Cannot read property 'featuredImage' of undefined"