### PR TITLE
Save thumbnail mime type with the meta data.

### DIFF
--- a/functions/save.php
+++ b/functions/save.php
@@ -121,7 +121,8 @@ class CptSaveThumbnail {
 					$_new_meta = array(
 						'file'=>$_filepath_info['basename'],
 						'width'=>intval($crop_width),
-						'height'=>intval($crop_height));
+						'height'=>intval($crop_height),
+                        'mime-type' => mime_content_type($_filepath));
 					if(!empty($dbImageSizes[$_imageSize->name]['crop'])) {
 						$_new_meta['crop'] = $dbImageSizes[$_imageSize->name]['crop'];
 					}


### PR DESCRIPTION
Some plugins, tools or frameworks for Wordpress require the `mime-type` to be present in the meta data of the thumbnail size.