### PR TITLE
Introduce new filter crop_thumbnails_filename

### DIFF
--- a/functions/save.php
+++ b/functions/save.php
@@ -67,7 +67,7 @@ class CptSaveThumbnail {
 				
 				$croppedSize = self::getCroppedSize($activeImageSize,$imageMetadata,$input);
 				
-				$currentFilePath = self::generateFilename($sourceImgPath, $croppedSize['width'], $croppedSize['height']);
+				$currentFilePath = self::generateFilename($sourceImgPath, $croppedSize['width'], $croppedSize['height'], $activeImageSize->crop);
 				self::addDebug("filename: ".$currentFilePath);
 				$currentFilePathInfo = pathinfo($currentFilePath);
 				$temporaryCopyFile = $GLOBALS['CROP_THUMBNAILS_HELPER']->getUploadDir().DIRECTORY_SEPARATOR.$currentFilePathInfo['basename'];
@@ -327,16 +327,17 @@ class CptSaveThumbnail {
 	 * @param string Path to the original (full-size) file.
 	 * @param int width of the new image
 	 * @param int height of the new image
+	 * @param boolean crop of the new image
 	 * @return string path to the new image
 	 */
-	protected static function generateFilename( $file, $w, $h ){
+	protected static function generateFilename( $file, $w, $h, $crop ){
 		$info = pathinfo($file);
 		$dir = $info['dirname'];
 		$ext = $info['extension'];
 		$name = wp_basename($file, '.'.$ext);
 		$suffix = $w.'x'.$h;
 		$destfilename = $dir.'/'.$name.'-'.$suffix.'.'.$ext;
-		return $destfilename;
+		return apply_filters('crop_thumbnails_filename', $destfilename, $file, $w, $h, $crop, $info);
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,19 @@ Parameters:
 
 
 
+### FILTER `crop_thumbnails_filename`
+
+The filter can be used to change the fullpath with filename of the newly created thumbnail.
+
+Parameters:
+* `$destfilename` - The full path of the file
+* `$file` - The original file
+* `$w` - The width of the thumbnail size
+* `$h` - The height of the thumbnail size
+* `$crop` - If true the thumbnail size is cropped
+
+
+
 ### FILTER `crop_thumbnails_before_update_metadata`
 
 The filter is called right before the attachement metadata are saved.


### PR DESCRIPTION
Hi @vollyimnetz,

I have a customer using my plugin [WP Real Thumbnail Generator](https://codecanyon.net/item/wordpress-real-thumbnail-generator-bulk-regenerate-upload-folder/18937507). This plugin allows you to outsource the thumbnail files to a different folder relative to the original file. Example:

![](https://matthias-web.com/wp-content/uploads/envato/rtg/rtg-wp-content.gif)

Unfortunely it does not correctly work with your plugin. I had a look at this and see that you are using the default WordPress way to generate the filename. It would be awesome to allow here a filter to allow custom filenames. This is the affected code:

https://github.com/vollyimnetz/crop-thumbnails/blob/c11bbcc84ee9fc5ba09222567c6a16fe79436996/functions/save.php#L324-L340

Best regards,
Matthew :-)