### PR TITLE
Delete old thumbnails when file name changes

### DIFF
--- a/functions/save.php
+++ b/functions/save.php
@@ -6,7 +6,7 @@ class CptSaveThumbnail {
 
 	protected static $debug = array();
 
-    /**
+	/**
 	 * Handle-function called via ajax request.
 	 * Check and crop multiple images. Update with wp_update_attachment_metadata if needed.
 	 * Input parameters:
@@ -144,13 +144,13 @@ class CptSaveThumbnail {
 	 * Whether we should delete old thumbnail file.
 	 *
 	 * We should delete when any of these happens:
-	 *	- the old size hasn't got the right image-size/image-ratio
-	 *	- the new image has a different file path
+	 *    - the old size hasn't got the right image-size/image-ratio
+	 *    - the new image has a different file path
 	 *
 	 * Otherwise, nobody will ever delete it correctly.
 	 *
-	 * @param  array  $oldSizeMetadata  The old image size from the database
-	 * @param  object  $activeImageSize The image size that should be used
+	 * @param  array  $oldSizeMetadata     The old image size from the database
+	 * @param  object $activeImageSize     The image size that should be used
 	 * @param  string $activeImageFilePath Full path to the new image
 	 * @return bool
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Crop-Thumbnails ===
-Contributors: volkmar-kantor
+Contributors: volkmar-kantor, tangrufus
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=volkmar%2ekantor%40gmx%2ede&lc=DE&item_name=Volkmar%20Kantor%20%2d%20totalmedial%2ede&item_number=crop%2dthumbnails&no_note=0&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest
 Tags: post-thumbnails, images, media library
 Requires at least: 4.6


### PR DESCRIPTION
Use case: https://github.com/ItinerisLtd/crop-thumbnails-cdn-cache-busting/blob/ae9556086b889dc1ad5499248a8159ffd68955fd/crop-thumbnails-cdn-cache-busting.php#L28-L42

Close #46