### PR TITLE
adding conditional to determine file extension using new image_editor_output_format hook

### DIFF
--- a/functions/save.php
+++ b/functions/save.php
@@ -388,6 +388,17 @@ class CptSaveThumbnail {
 		$info = pathinfo($file);
 		$dir = $info['dirname'];
 		$ext = $info['extension'];
+
+		/**
+		 * since WordPress 5.8 the image extension / MIME type may differ from that of the
+		 * original file so we'll use the below hook to check if any defaults are overwritten.
+		 */
+		$outputFormats = apply_filters('image_editor_output_format', [], $file);
+		$fileTypeInformations = wp_check_filetype($file);
+		if (isset($outputFormats[$fileTypeInformations['type']])) {
+			$ext = array_search($outputFormats[$fileTypeInformations['type']], wp_get_mime_types(), true);
+		}
+
 		$name = wp_basename($file, '.'.$ext);
 		if(!empty($imageMetadata['original_image'])) {
 			$name = wp_basename($imageMetadata['original_image'], '.'.$ext);


### PR DESCRIPTION
This small addition _should_ allow the file extension of generated thumbnails to match the specified format for sub-sizes rather than the format of the original image.

Since WordPress 5.8 the `image_editor_output_format` hook makes it possible for generated thumbnails (sub-sizes) to be of a different image format than the original image. This is part of [WordPress adding support for WebP](https://make.wordpress.org/core/2021/06/07/wordpress-5-8-adds-webp-support/), and eventually will also include other formats such as `AVIF` and `JPEGXL`.

It was a bit of a pain to get the extension from the file path so my method may not be the best. I tested it in various scenarios (including previous WordPress versions) and it falls back to JPG gracefully from what I can tell. If anyone has a better suggested fix I'd be happy to hear it!

Fixes #55 