### PR TITLE
[Dev] Added filter 'crop_thumbnails_new_size_metadata'

### DIFF
--- a/functions/save.php
+++ b/functions/save.php
@@ -300,7 +300,8 @@ class CptSaveThumbnail {
 		$imageMetadata['sizes'][$imageSizeName] = array_merge($oldValues,$newValues);
 		
 		do_action('crop_thumbnails_after_save_new_thumb', $fullFilePath, $imageSizeName, $imageMetadata['sizes'][$imageSizeName] );
-		return $imageMetadata;
+		
+		return apply_filters('crop_thumbnails_new_size_metadata', $imageMetadata, $imageSizeName, $croppedInput->sourceImageId );
 	}
 
 	/**


### PR DESCRIPTION
This filter allows changing the generated metadata of the cropped file.

It was useful for me when I needed to append metadata for the active size right after cropping.