### PR TITLE
Add image/jpg to allowed mime types

### DIFF
--- a/functions/backendpreparer.php
+++ b/functions/backendpreparer.php
@@ -6,7 +6,7 @@ namespace crop_thumbnails;
  */
 class CropPostThumbnailsBackendPreparer {
 	
-	protected $allowedMime = ['image/webp','image/jpeg','image/png'];
+	protected $allowedMime = ['image/webp','image/jpeg','image/jpg','image/png'];
 	
 	public function __construct() {
 		if ( is_admin() ) {


### PR DESCRIPTION
I struggled for a while with the Crop thumbnail button not showing up on some files that were uploaded before activating the plugin. It turned out the reason was that the files were uploaded with the `image/jpg` mime type instead of `image/jpeg`

On the Media library screen we can see that I uploaded the exact same file twice.

<img width="1418" alt="Capture d’écran 2023-12-08 à 12 33 02" src="https://github.com/vollyimnetz/crop-thumbnails/assets/6853334/94dfd8eb-4fbf-4abb-8df9-3316733d4c27">

The first one was uploaded with the `image/jpg` mime type and the crop button does not show up.

<img width="1418" alt="Capture d’écran 2023-12-08 à 12 33 59" src="https://github.com/vollyimnetz/crop-thumbnails/assets/6853334/5c5b33b1-5b82-45da-a836-e872480915a6">

The second one was uploaded with the `image/jpeg` mime type and the crop button buttons shows up.

<img width="1418" alt="Capture d’écran 2023-12-08 à 12 34 23" src="https://github.com/vollyimnetz/crop-thumbnails/assets/6853334/02cbf954-84bb-4273-b5a6-4fce830be3bf">

The Crop thumbnail button does show up in the featured image section of the post for both mime types.  

I have no idea why Wordpress saves inconsistent mime types but adding `image/jpg` to the allowed mime types of the plugin does the trick.



